### PR TITLE
Updating forum topic URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Official BBCode Discourse plugin
 
-See: [meta.discourse.org/t/discourse-bbcode/65425](meta.discourse.org/t/discourse-bbcode/65425)
+See: [https://meta.discourse.org/t/discourse-bbcode/65425](meta.discourse.org/t/discourse-bbcode/65425)
 
 


### PR DESCRIPTION
I've changed the topic's address to absolute by adding `https://` prefix, as the link was redirecting _inside_ Github (github.com/meta.discourse.org/t/...)