### PR TITLE
FEATURE: re-implement [size]/[color]/[bgcolor] with CSS

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/bbcode.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/bbcode.js.es6
@@ -11,7 +11,7 @@ function replaceFontColor(text) {
     (text = text.replace(
       /\[color=([^\]]+)\]((?:(?!\[color=[^\]]+\]|\[\/color\])[\S\s])*)\[\/color\]/gi,
       function (match, p1, p2) {
-        return `<font color='${p1}'>${p2}</font>`;
+        return `<span style='color:${p1}'>${p2}</span>`;
       }
     ))
   ) {}
@@ -24,7 +24,7 @@ function replaceFontSize(text) {
     (text = text.replace(
       /\[size=([^\]]+)\]((?:(?!\[size=[^\]]+\]|\[\/size\])[\S\s])*)\[\/size\]/gi,
       function (match, p1, p2) {
-        return `<font size='${p1}'>${p2}</font>`;
+        return `<span style='font-size:${p1}px'>${p2}</span>`;
       }
     ))
   ) {}
@@ -37,7 +37,7 @@ function replaceFontFace(text) {
     (text = text.replace(
       /\[font=([^\]]+)\]((?:(?!\[font=[^\]]+\]|\[\/font\])[\S\s])*)\[\/font\]/gi,
       function (match, p1, p2) {
-        return `<font face='${p1}'>${p2}</font>`;
+        return `<span style='font-family:${p1}'>${p2}</span>`;
       }
     ))
   ) {}
@@ -66,17 +66,29 @@ function setupMarkdownIt(md) {
 
   ruler.push("size", {
     tag: "size",
-    wrap: wrap("font", "size"),
+    wrap: wrap(
+      "span", 
+      "style",
+      (tagInfo) => "font-size:" + tagInfo.attrs._default + "px"
+      ),
   });
 
   ruler.push("font", {
     tag: "font",
-    wrap: wrap("font", "face"),
+    wrap: wrap(
+      "span", 
+      "style",
+      (tagInfo) => "font-family:" + tagInfo.attrs._default
+      ),
   });
 
   ruler.push("color", {
     tag: "color",
-    wrap: wrap("font", "color"),
+    wrap: wrap(
+      "span", 
+      "style",
+      (tagInfo) => "color:" + tagInfo.attrs._default
+      ),
   });
 
   ruler.push("bgcolor", {
@@ -234,9 +246,9 @@ export function setup(helper) {
   helper.allowList({
     custom(tag, name, value) {
       if (tag === "span" && name === "style") {
-        return /^(font-size:(xx-small|x-small|small|medium|large|x-large|xx-large)|background-color:#?[a-zA-Z0-9]+)$/.exec(
+        return /^(font-size:(xx-small|x-small|small|medium|large|x-large|xx-large|[0-9]*px)|color:#?[a-zA-Z0-9]+|font-family:[^;']*(;)?|background-color:#?[a-zA-Z0-9]+)$/.exec(
           value
-        );
+          );
       }
 
       if (tag === "div" && name === "style") {


### PR DESCRIPTION
I find that the original implementation of these tags uses a deprecated HTML tag, which may not be supported by some browsers, so I re-implement them with CSS style. 