### PR TITLE
Migrate deprecated html tags for [color], [size] and [font]

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/bbcode.js
+++ b/assets/javascripts/lib/discourse-markdown/bbcode.js
@@ -229,16 +229,13 @@ export function setup(helper) {
     "div.sepquote",
     "span.smallfont",
     "blockquote.indent",
-    "font[color=*]",
-    "font[size=*]",
-    "font[face=*]",
     "ol[type=*]",
   ]);
 
   helper.allowList({
     custom(tag, name, value) {
       if (tag === "span" && name === "style") {
-        return /^(font-size:(xx-small|x-small|small|medium|large|x-large|xx-large)|background-color:#?[a-zA-Z0-9]+)$/.exec(
+        return /^(font-size:(xx-small|x-small|small|medium|large|x-large|xx-large|[0-9]{1,3}%)|background-color:#?[a-zA-Z0-9]+|color:[a-zA-Z0-9]+|font-family:[\s\S]+)$/.exec(
           value
         );
       }

--- a/assets/javascripts/lib/discourse-markdown/bbcode.js
+++ b/assets/javascripts/lib/discourse-markdown/bbcode.js
@@ -241,7 +241,7 @@ export function setup(helper) {
   helper.allowList({
     custom(tag, name, value) {
       if (tag === "span" && name === "style") {
-        return /^(font-size:(xx-small|x-small|small|medium|large|x-large|xx-large|[0-9]{1,3}%)|background-color:#?[a-zA-Z0-9]+|color:[a-zA-Z0-9]+|font-family:[\s\S]+)$/.exec(
+        return /^(font-size:(xx-small|x-small|small|medium|large|x-large|xx-large|[0-9]{1,3}%)|background-color:#?[a-zA-Z0-9]+|color:#?[a-zA-Z0-9]+|font-family:[\s\S]+)$/.exec(
           value
         );
       }

--- a/assets/javascripts/lib/discourse-markdown/bbcode.js
+++ b/assets/javascripts/lib/discourse-markdown/bbcode.js
@@ -6,7 +6,7 @@ function replaceFontColor(text) {
     (text = text.replace(
       /\[color=([^\]]+)\]((?:(?!\[color=[^\]]+\]|\[\/color\])[\S\s])*)\[\/color\]/gi,
       function (match, p1, p2) {
-        return `<font color='${p1}'>${p2}</font>`;
+        return `<span style='color:${p1}'>${p2}</span>`;
       }
     ))
   ) {}
@@ -19,7 +19,7 @@ function replaceFontSize(text) {
     (text = text.replace(
       /\[size=([^\]]+)\]((?:(?!\[size=[^\]]+\]|\[\/size\])[\S\s])*)\[\/size\]/gi,
       function (match, p1, p2) {
-        return `<font size='${p1}'>${p2}</font>`;
+        return `<span style='font-size:${p1}%'>${p2}</span>`;
       }
     ))
   ) {}
@@ -32,7 +32,7 @@ function replaceFontFace(text) {
     (text = text.replace(
       /\[font=([^\]]+)\]((?:(?!\[font=[^\]]+\]|\[\/font\])[\S\s])*)\[\/font\]/gi,
       function (match, p1, p2) {
-        return `<font face='${p1}'>${p2}</font>`;
+        return `<span style="font-family:'${p1}'">${p2}</span>`;
       }
     ))
   ) {}
@@ -61,17 +61,26 @@ function setupMarkdownIt(md) {
 
   ruler.push("size", {
     tag: "size",
-    wrap: wrap("font", "size"),
+    wrap: wrap(
+      "span",
+      "style",
+      (tagInfo) => "font-size:" + tagInfo.attrs._default.trim() + "%"),
   });
 
   ruler.push("font", {
     tag: "font",
-    wrap: wrap("font", "face"),
+    wrap: wrap(
+      "span",
+      "style",
+      (tagInfo) => "font-family:" + tagInfo.attrs._default.trim()),
   });
 
   ruler.push("color", {
     tag: "color",
-    wrap: wrap("font", "color"),
+    wrap: wrap(
+      "span",
+      "style",
+      (tagInfo) => "color:" + tagInfo.attrs._default.trim()),
   });
 
   ruler.push("bgcolor", {

--- a/assets/javascripts/lib/discourse-markdown/bbcode.js
+++ b/assets/javascripts/lib/discourse-markdown/bbcode.js
@@ -61,26 +61,32 @@ function setupMarkdownIt(md) {
 
   ruler.push("size", {
     tag: "size",
+
     wrap: wrap(
       "span",
       "style",
-      (tagInfo) => "font-size:" + tagInfo.attrs._default.trim() + "%"),
+      (tagInfo) => "font-size:" + tagInfo.attrs._default.trim() + "%"
+    ),
   });
 
   ruler.push("font", {
     tag: "font",
+
     wrap: wrap(
       "span",
       "style",
-      (tagInfo) => "font-family:" + tagInfo.attrs._default.trim()),
+      (tagInfo) => `font-family:'${tagInfo.attrs._default.trim()}'`
+    ),
   });
 
   ruler.push("color", {
     tag: "color",
+
     wrap: wrap(
       "span",
       "style",
-      (tagInfo) => "color:" + tagInfo.attrs._default.trim()),
+      (tagInfo) => "color:" + tagInfo.attrs._default.trim()
+    ),
   });
 
   ruler.push("bgcolor", {

--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -20,7 +20,7 @@ describe PrettyText do
 
   it 'can apply font bbcode' do
     cooked = PrettyText.cook "hello [font=usa]usa[/font] text"
-    html = '<p>hello <span style="font-family:\'usa\'">usa</font> text</p>'
+    html = '<p>hello <span style="font-family:\'usa\'">usa</span> text</p>'
 
     expect(cooked).to eq(html)
   end

--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -6,21 +6,21 @@ describe PrettyText do
 
   it 'can apply color bbcode' do
     cooked = PrettyText.cook "hello [color=red]RED[/color] world"
-    html = '<p>hello <font color="red">RED</font> world</p>'
+    html = '<p>hello <span style="color:red">RED</span> world</p>'
 
     expect(cooked).to eq(html)
   end
 
   it 'can apply size bbcode' do
-    cooked = PrettyText.cook "hello [size=100]BIG[/size] text"
-    html = '<p>hello <font size="100">BIG</font> text</p>'
+    cooked = PrettyText.cook "hello [size=150]BIG[/size] text"
+    html = '<p>hello <span style="font-size:150%">BIG</span> text</p>'
 
     expect(cooked).to eq(html)
   end
 
   it 'can apply font bbcode' do
     cooked = PrettyText.cook "hello [font=usa]usa[/font] text"
-    html = '<p>hello <font face="usa">usa</font> text</p>'
+    html = '<p>hello <span style="font-family:\'usa\'">usa</font> text</p>'
 
     expect(cooked).to eq(html)
   end

--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 describe PrettyText do
 
   it 'can apply color bbcode' do
-    cooked = PrettyText.cook "hello [color=red]RED[/color] world"
-    html = '<p>hello <span style="color:red">RED</span> world</p>'
+    cooked = PrettyText.cook "hello [color=red]RED[/color] or [color=#00ff00]BLUE[/color] world"
+    html = '<p>hello <span style="color:red">RED</span> or <span style="color:#00ff00">BLUE</span> world</p>'
 
     expect(cooked).to eq(html)
   end


### PR DESCRIPTION
Hi everyone :smiley: 

The plugin currently maps `[color]`, `[size]` and `[font]` BBcodes to `<font>` html tag. The problem is that `<font>` html tag is not supported in html5 standard [(ref)](https://www.w3schools.com/tags/tag_font.asp) and its recommended replacement is `<span>` with inline custom CSS

Another issue is the expected behavior of `[size]` BBcode. Currently, the value passed to the tag is used 'as is' by the `<font>` size attribute. The `<font>` tag uses a scale from 1 to 7, with 3 being the default [(ref)](https://www.geeksforgeeks.org/html-font-size-attribute/), while the phpBB standard expect a percentage value in the range 20-200 [(ref)](https://www.phpbb.com/community/help/bbcode#f1r1). This change of behavior can lead to bad looking text when migrating from existing phpBB instances and may be an indirection when using this tag, since it would be expected to behave as its equivalent BBcode

This PR aims to change the translation rule for `[color]`, `[size]` and `[font]` in order to comply with html5 standard, as well as maintain the expected behavior of `[size]` in relation of its equivalent BBcode in phpBB

Relevant links
- [W3schools on font tag](https://www.w3schools.com/tags/tag_font.asp)
- [Geeks for geeks on font size attribute](https://www.geeksforgeeks.org/html-font-size-attribute/)
- [phpBB BBcode reference](https://www.phpbb.com/community/help/bbcode)