### PR TITLE
FIX: BBCode parsing specs

### DIFF
--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -33,7 +33,7 @@ describe PrettyText do
   end
 
   it "can apply font bbcode with space" do
-    cooked = PrettyText.cook "hello [font=Times New Roman]Times New Roman[/font] text"
+    cooked = PrettyText.cook "hello [font='Times New Roman']Times New Roman[/font] text"
     html = '<p>hello <span style="font-family:\'Times New Roman\'">Times New Roman</span> text</p>'
 
     expect(cooked).to eq(html)


### PR DESCRIPTION
Requires https://github.com/discourse/discourse/pull/27173 to be merged.

Will add a `.discourse-compatibility` once merged.